### PR TITLE
[FIX] Added a note about wrong EXEC value

### DIFF
--- a/brd2svg/run.sh
+++ b/brd2svg/run.sh
@@ -26,10 +26,14 @@ fi
 # Check if EXEC value really points to EAGLE binary file
 if ! [ -f "$EXEC" ]
 then
-  echo "Error: Invalid value of EXEC variable."
-  echo "Please, make sure that the EXEC variable in this (run.sh) script contains a FULL path to the EAGLE executable. \
-  For example, for linux users it can look like that: /opt/eagle/bin/eagle. And for Mac OS users: \
-  /Applications/EAGLE-7.3.0/EAGLE.app/Contents/MacOS/EAGLE."
+  printf "\
+  Error: Invalid value of EXEC variable.
+
+  Please, make sure that the EXEC variable in this (run.sh) script contains a FULL path to the EAGLE executable FILE.
+
+  For example, for linux users it can look like that: /opt/eagle/bin/eagle.
+  And for Mac OS users: /Applications/EAGLE-7.3.0/EAGLE.app/Contents/MacOS/EAGLE.
+"
   exit 1
 fi
 

--- a/brd2svg/run.sh
+++ b/brd2svg/run.sh
@@ -23,6 +23,16 @@ then
   WORKPATH=$1
 fi
 
+# Check if EXEC value really points to EAGLE binary file
+if ! [ -f "$EXEC" ]
+then
+  echo "Error: Invalid value of EXEC variable."
+  echo "Please, make sure that the EXEC variable in this (run.sh) script contains a FULL path to the EAGLE executable. \
+  For example, for linux users it can look like that: /opt/eagle/bin/eagle. And for Mac OS users: \
+  /Applications/EAGLE-7.3.0/EAGLE.app/Contents/MacOS/EAGLE."
+  exit 1
+fi
+
 # Preprocess .brd files - MUST BE IN EAGLE XML FORMAT
 if [ -n "$PREPROCESS" ] && [ "$PREPROCESS" -gt 0 ]; then
   # Preprocess each .brd file


### PR DESCRIPTION
If EXEC variable value points to the existing path, but this path points to the directory rather than Eagle executable, than the following attempt to run `brd2svg` script on line 66 will fail with confusing error: "unable to start brd_file_name_here.brd". To prevent so, an additional check was added: the value of EXEC variable must point strictly to the existing **file** and nothing else. 

Unfortunately, I can't figure out right now how to check if the mentioned file is really EAGLE executable and not an image, for example.

Inspired by this issue: https://github.com/fritzing/eagle2fritzing/issues/21