### PR TITLE
Update PighiXXX credit (potentially dangerous URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,4 @@ Note about `<nudge>` elements in the `.params` file: I'm trying to avoid some/mo
 
 Subparts Art Attribution
 ============================================
-MicroSD Card holder, ESP-12E module, and Bluefruit LE (MDBT40) art is from PigHixx's lovely diagrams!
-http://www.pighixxx.com/
+MicroSD Card holder, ESP-12E module, and Bluefruit LE (MDBT40) art by @AlbertoPiganti (PighiXXX).


### PR DESCRIPTION
This link in the README is no longer pointing to the original resource since approximately 2018. There's [an archive of the site](https://github.com/BelKed/pighixxx-uploads-archive).